### PR TITLE
Speeds up completion startup

### DIFF
--- a/modules/completion/init.zsh
+++ b/modules/completion/init.zsh
@@ -15,7 +15,15 @@ fi
 fpath=("${0:h}/external/src" $fpath)
 
 # Load and initialize the completion system ignoring insecure directories.
-autoload -Uz compinit && compinit -i
+# Will only rebuild ~/.zcompdump once per day
+autoload -Uz compinit
+if [ $(date +'%j') != $(stat -f '%Sm' -t '%j' ~/.zcompdump) ]; then
+  compinit
+else
+  compinit -C
+fi
+
+
 
 #
 # Options


### PR DESCRIPTION
Before this change, completion startup would rebuild ~/.zcompdump each
time a new shell was created.

After this change, completion startup will only rebuild ~/.zcompdump once per
day.

This dramatically speeds up the startup time for Prezto for all but the
first startup of the day.
